### PR TITLE
fix remote builds by specifying rust-path and rust-channel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,9 @@ parts:
   k26-default-bitstreams:
     plugin: rust
     source: .
+    rust-path:
+      - k26-default-bitstreams
+    rust-channel: "stable"
   bitstream-data:
     plugin: dump
     source: https://github.com/Xilinx/kria-base-firmware


### PR DESCRIPTION
succeeded:
```
→ snapcraft remote-build --build-for arm64
remote-build is experimental and is subject to change. Use with caution.
All data sent to remote builders will be publicly available. Are you sure you want to continue? [y/N]: y
Build completed. logs... :: Downloading https://launchpad.net/~artiepoole/artiepoole-craft-remote-build/+snap/snapcraft-k26-default-…
Log files: snapcraft-k26-default-bitstreams-efcfc92062e57c32751bcb53fc6516f7_arm64_2025-08-05T15:39:34.txt
Artifacts: k26-default-bitstreams_0.1.0+git20250805.bf0284c_arm64.snap
```
