### PR TITLE
snap: add bitstreams content interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,17 +13,18 @@ plugs:
     bus: system
     name: com.canonical.fpgad
 slots:
-  bitstreams:
+  fpgad-bitstreams:
     interface: content
     source:
-      read: $SNAP/data
+      read:
+        - $SNAP/data/k26-starter-kits
 apps:
   k26-default-bitstreams:
     command: bin/k26-default-bitstreams
     daemon: oneshot
     plugs:
       - fpgad-dbus
-    restart-condition: always .github/workflows/integration_tests.yaml.yml
+    restart-condition: always
     start-timeout: 30s
 parts:
   version:
@@ -37,6 +38,9 @@ parts:
       craftctl set version="$cargo_version+git$(date +'%Y%m%d').$(git describe --always --exclude '*')"
   k26-default-bitstreams:
     plugin: rust
+    rust-channel: 'stable'
+    rust-path:
+      - k26-default-bitstreams
     source: .
   bitstream-data:
     plugin: dump


### PR DESCRIPTION
Adding `bitstreams` content interface to provide files to consuming snaps. Using `source` allows us to provide all directories inside given path.