### PR TITLE
root: snap: alternative approach using overlay to apply firmware

### DIFF
--- a/k26-default-bitstreams/src/proxies/control_proxy.rs
+++ b/k26-default-bitstreams/src/proxies/control_proxy.rs
@@ -19,11 +19,11 @@ pub trait Control {
         flags: u32,
     ) -> Result<String>;
 
-    async fn write_bitstream_direct(
+    async fn apply_overlay(
         &self,
-        platform_string: &str,
-        device_handle: &str,
-        bitstream_path_str: &str,
+        platform_compat_str: &str,
+        overlay_handle: &str,
+        overlay_source_path: &str,
         firmware_lookup_path: &str,
     ) -> Result<String>;
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,9 +42,12 @@ parts:
     source: https://github.com/Xilinx/kria-base-firmware
     source-type: git
     build-packages:
+      - device-tree-compiler
       - xilinx-bootgen
     override-build: |
       bootgen -image k26_starter_kits/k26_starter_kits.bif -arch zynqmp -o k26_starter_kits/k26_starter_kits.bit.bin -w
+      dtc -I dts -O dtb -o k26_starter_kits/k26_starter_kits.dtbo k26_starter_kits/k26_starter_kits.dtsi
       mkdir -p $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits
       cp k26_starter_kits/k26_starter_kits.bit.bin $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/
+      cp k26_starter_kits/k26_starter_kits.dtbo $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/
       cp LICENSE-BINARIES $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/


### PR DESCRIPTION
Please note that, without `--devmode`, fpgad does not have access to the required configfs files necessary to apply an overlay due to outstanding discussions about how to handle those accesses in snap (if at all...)