### PR TITLE
snapcraft: ship .dtbo and shell.json for -load testing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,8 +69,16 @@ parts:
     source-type: git
     build-packages:
       - xilinx-bootgen
+      - device-tree-compiler
     override-build: |
-      cd k26_starter_kits && bootgen -image k26_starter_kits.bif -arch zynqmp -o k26_starter_kits.bit.bin -w && cd ../
+      # build bitstream and device tree overlay
+      cd k26_starter_kits
+      bootgen -image k26_starter_kits.bif -arch zynqmp -o k26_starter_kits.bit.bin -w
+      dtc -I dts -O dtb -@ -o k26_starter_kits.dtbo k26_starter_kits.dtsi
+      cd ../
+      # install the files
       mkdir -p $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits
-      cp k26_starter_kits/k26_starter_kits.bit.bin $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/
+      cp k26_starter_kits/*.dtbo $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/
+      cp k26_starter_kits/*.bit.bin $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/
+      cp k26_starter_kits/shell.json $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/
       cp LICENSE-BINARIES $SNAPCRAFT_PART_INSTALL/data/k26-starter-kits/


### PR DESCRIPTION
I want to use this package to test fpgad on k26 devices. Therefore I want to provide the dtbo, even though it is not used in the source code here, I want to ship it as part of this package. 
The alternative is to make a new snapcraft.yaml only snap package which contains both k24 and k26 files and no code to load them